### PR TITLE
Token typo - Update 'token' variable in config file

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,5 @@
 {
-    "token": "YOUR_API_TOKEN",
+    "api_token": "YOUR_API_TOKEN",
     "start_date": "2019-01-01T00:00:00Z",
     "user_agent": "tap-kustomer <api_user_email@your_company.com>",
     "date_window_size": "60"


### PR DESCRIPTION
# Description of change
"Config is missing required keys: ['api_token'] error occurred. Therefore, updated 'token' variable to be 'api_token'

# Rollback steps
 - revert this branch
