### PR TITLE
Update config.json.example to include page_size_limit

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -2,5 +2,6 @@
     "api_token": "YOUR_API_TOKEN",
     "start_date": "2019-01-01T00:00:00Z",
     "user_agent": "tap-kustomer <api_user_email@your_company.com>",
-    "date_window_size": "60"
+    "date_window_size": "60",
+    "page_size_limit": "300"
 }


### PR DESCRIPTION
page_size_limit is supposed to be user configurable in order to account for hundreds of rows with the exact same updated timestamp. In Stitch, this is not available in the GUI and the integration runs with a fixed page_size_limit value of 100, causing pagination issues. comments in the sync.py script say this should be at least 300.

I don't assume this example file will directly affect the Stitch GUI, but the example file should include it at least.

# Description of change
added page_size_limit

# QA steps
(I don't know what to add here)
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
