### PR TITLE
Update sync.py

### DIFF
--- a/tap_kustomer/sync.py
+++ b/tap_kustomer/sync.py
@@ -10,7 +10,7 @@ from tap_kustomer.streams import STREAMS
 LOGGER = singer.get_logger()
 
 DATE_WINDOW_DEFAULT = 60
-RESULT_RETURN_LIMIT = 100
+RESULT_RETURN_LIMIT = 300
 
 
 def write_schema(catalog, stream_name):


### PR DESCRIPTION
# Description of change
the fallback page_size_limit is set to 100 when this parameter is not provided in config.json, however the comments in code clearly say:
    # Tap configurable page size. 300 value currently as API often returns
    # 200+ which have the same date time.

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
