### PR TITLE
Update sync.py to increase RESULT_RETURN_LIMIT

### DIFF
--- a/tap_kustomer/sync.py
+++ b/tap_kustomer/sync.py
@@ -10,7 +10,7 @@ from tap_kustomer.streams import STREAMS
 LOGGER = singer.get_logger()
 
 DATE_WINDOW_DEFAULT = 60
-RESULT_RETURN_LIMIT = 100
+RESULT_RETURN_LIMIT = 500
 
 
 def write_schema(catalog, stream_name):


### PR DESCRIPTION
As per comments in the code and first hand experience with eternal pagination as outlined in issue #12 , RESULT_RETURN_LIMIT needs to be increased for to account for hundreds of rows with the same updated_at timestamp. API docs say the max value for page size is 500, and testing done by @mascah proved that even setting a page size value of 1000 only returned 500 rows.

# Description of change
(write a short description here or paste a link to JIRA)

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
