### PR TITLE
Update Kustomer domain

### DIFF
--- a/tap_kustomer/client.py
+++ b/tap_kustomer/client.py
@@ -99,7 +99,7 @@ class KustomerClient():
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False
-        self.base_url = 'https://api.kustomerapp.com/{}'.format(API_VERSION)
+        self.base_url = 'https://api.prod2.kustomerapp.com/{}'.format(API_VERSION)
 
     def __enter__(self):
         self.__verified = self.check_token()


### PR DESCRIPTION
# Description of change
Kustomer's main domain changed: `https://api.kustomerapp.com` is broken. We need to use `https://api.prod2.kustomerapp.com`

# QA steps
 - [ ] automated tests passing
 - [ ] manual qa steps passing (list below)
 
# Risks

# Rollback steps
 - revert this branch
